### PR TITLE
Updates icu4c forumla

### DIFF
--- a/Formula/icu4c@58.1.rb
+++ b/Formula/icu4c@58.1.rb
@@ -25,8 +25,7 @@ class Icu4cAT581 < Formula
     ENV.universal_binary if build.universal?
     ENV.cxx11 if build.cxx11?
 
-    args = %W[--prefix=#{prefix} --disable-samples --disable-tests --enable-static]
-    args << "--with-library-bits=64" if MacOS.prefer_64_bit?
+    args = %W[--prefix=#{prefix} --disable-samples --disable-tests --enable-static --with-library-bits=64]
 
     cd "source" do
       system "./configure", *args


### PR DESCRIPTION
This removes the disabled call to MacOS.prefer_64_bits? so that the formula can be built again.

Issue #1 